### PR TITLE
Fix: Stabilize row IDs in supplemental report schedules

### DIFF
--- a/frontend/src/views/AllocationAgreements/AddEditAllocationAgreements.jsx
+++ b/frontend/src/views/AllocationAgreements/AddEditAllocationAgreements.jsx
@@ -205,7 +205,7 @@ export const AddEditAllocationAgreements = () => {
         compliancePeriod,
         isNewSupplementalEntry:
           isSupplemental && item.complianceReportId === +complianceReportId,
-        id: uuid()
+      id: item.id || uuid() // <--- Preserve existing id, or assign new if missing
       }))
 
       setRowData(updatedRowData)

--- a/frontend/src/views/NotionalTransfers/AddEditNotionalTransfers.jsx
+++ b/frontend/src/views/NotionalTransfers/AddEditNotionalTransfers.jsx
@@ -258,7 +258,8 @@ export const AddEditNotionalTransfers = () => {
           ...item,
           complianceReportId,
           isNewSupplementalEntry:
-            isSupplemental && item.complianceReportId === +complianceReportId
+          isSupplemental && item.complianceReportId === +complianceReportId,
+        id: item.id || uuid() // Explicitly preserve existing id, or assign new if missing
         })) ?? []
       setRowData(updatedRowData)
     } else {


### PR DESCRIPTION
Addresses issues where editing rows in Allocation Agreement and Notional Transfer tables caused unexpected reordering or UI splitting.

The root cause was unstable client-side row identifiers (`id`) used by AG Grid. When data was refreshed or updated (e.g., after saving an edit), these IDs were sometimes regenerated for existing rows. This led AG Grid to treat them as new or different rows, resulting in incorrect ordering.

Changes:
- Modified `useEffect` hooks in `AddEditAllocationAgreements.jsx` and `AddEditNotionalTransfers.jsx` to ensure that when row data is processed (e.g., from a fetch call), existing `item.id` values are preserved. A new `uuid()` is now only assigned if `item.id` is initially missing.
- Confirmed that `handleScheduleSave` correctly merges data in a way that respects the client-side `id`.